### PR TITLE
explicity set 'destination' to 'acs' so it isn't set to 'audience'

### DIFF
--- a/app.js
+++ b/app.js
@@ -54,6 +54,7 @@ var idpOptions = {
   key:                  fs.readFileSync(path.join(__dirname, 'server-key.pem')),
   audience:             argv.audience,
   recipient:            argv.acs, 
+  destination:          argv.acs,
   digestAlgorithm:      'sha1',      
   signatureAlgorithm:   'rsa-sha1',
   RelayState:           argv.relaystate,


### PR DESCRIPTION
Compliance with Section 3.4.5.2 of the saml-bindings-2.0-os specification.
