### PR TITLE
Use assertionConsumerServiceURL from SAMLRequest if provided

### DIFF
--- a/views/user.hbs
+++ b/views/user.hbs
@@ -6,6 +6,8 @@
 	  <div class="panel-body">
 
 			<form class="form-horizontal" role="form" method="POST">
+				
+				<input type='hidden' name="acs" value='{{acs}}'/>
 
 				<div class="form-group">
 				  <label for="login" class="col-sm-3 control-label">Login</label>


### PR DESCRIPTION
A SAMLRequest can contain an assertionConsumerServiceURL.
I added support for using this property from the SAMLRequest to override the command line value.
If it is not present, the command line value will be used.