### PR TITLE
Key/cert handling fixes and improvements

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 This app provides a simple Identity Provider (IdP) to test SAML 2.0 Service Providers (SPs) with the [SAML 2.0 Web Browser SSO Profile](http://en.wikipedia.org/wiki/SAML_2.0#Web_Browser_SSO_Profile).
 
-> **This sample is not intended for use with production systems!** 
+> **This sample is not intended for use with production systems!**
 
 ## Docker Installation and Startup
 
@@ -16,18 +16,22 @@ Simply modify Dockerfile to specify your own parameters.
 1. `npm install`
 2. `bower install`
 3. `openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/C=US/ST=California/L=San Francisco/O=JankyCo/CN=Test Identity Provider' -keyout idp-private-key.pem -out idp-public-cert.pem -days 7300`
-    
-> [Bower](http://bower.io/), a front-end package manager, can be installed with `npm install -g bower`    
+
+> [Bower](http://bower.io/), a front-end package manager, can be installed with `npm install -g bower`
 
 ### Usage
 
-  node app.js --acs {POST URL} --aud {audience}
-  
+```
+node app.js --acs {POST URL} --aud {audience}
+```
+
 Open `http://localhost:7000` in your browser to start an IdP initiated flow to your SP
 
 #### Example
 
-  node app.js --acs https://foo.okta.com/auth/saml20/example --aud https://www.okta.com/saml2/service-provider/spf5aFRRXFGIMAYXQPNV
+```
+node app.js --acs https://foo.okta.com/auth/saml20/example --aud https://www.okta.com/saml2/service-provider/spf5aFRRXFGIMAYXQPNV
+```
 
 #### Options
 
@@ -38,12 +42,12 @@ Most parameters can be defined with the following command-line arguments:
   --issuer, --iss                   IdP Issuer URI                                                                                       [required]  [default: "urn:example:idp"]
   --acsUrl, --acs                   SP Assertion Consumer URL                                                                            [required]
   --audience, --aud                 SP Audience URI                                                                                      [required]
-  --relayState, --rs                Default SAML RelayState for SAMLResponse                                                           
+  --relayState, --rs                Default SAML RelayState for SAMLResponse
   --disableRequestAcsUrl, --static  Disables ability for SP AuthnRequest to specify Assertion Consumer URL                               [default: false]
-  --encryptionCert, --encCert       SP Certificate (pem) for Assertion Encryption                                                      
+  --encryptionCert, --encCert       SP Certificate (pem) for Assertion Encryption
   --encryptionPublicKey, --encKey   SP RSA Public Key (pem) for Assertion Encryption (e.g. openssl x509 -pubkey -noout -in sp-cert.pem)
-  --httpsPrivateKey                 Web Server TLS/SSL Private Key (pem)                                                               
-  --httpsCert                       Web Server TLS/SSL Certificate (pem)                                                               
+  --httpsPrivateKey                 Web Server TLS/SSL Private Key (pem)
+  --httpsCert                       Web Server TLS/SSL Certificate (pem)
   --https                           Enables HTTPS Listener (requires httpsPrivateKey and httpsCert)                                      [required]  [default: false]
 ```
 
@@ -157,3 +161,12 @@ Encrypted assertions require both a certificate and public key from the target s
 PEM files that contain the header `-----BEGIN CERTIFICATE-----` can also be converted to  just the public key which is a file with just the `-----BEGIN PUBLIC KEY-----` header
 
 `openssl x509 -pubkey -noout -in cert.pem > pub.key`
+
+
+## Passing key/cert pairs from environment variables
+
+Key/cert pairs can also be passed from environment variables.
+
+```
+node app.js --acs {POST URL} --aud {audience} --cert="$SAML_CERT" --key="$SAML_KEY"
+```

--- a/app.js
+++ b/app.js
@@ -28,6 +28,23 @@ var app                 = express(),
     httpServer;
 
 
+function isCertString(value) {
+    return /-----BEGIN CERTIFICATE-----[^-]*-----END CERTIFICATE-----/.test(value);
+}
+
+function isPrivateKeyString(value) {
+    return /-----BEGIN RSA PRIVATE KEY-----\n[^-]*\n-----END RSA PRIVATE KEY-----/.test(value);
+}
+
+function bufferFromString(value) {
+  if (Buffer.hasOwnProperty('from')) {
+    // node 6+
+    return Buffer.from(value);
+  } else {
+    return new Buffer(value);
+  }
+}
+
 /**
  * Arguments
  */
@@ -121,20 +138,26 @@ var argv = yargs
   })
   .example('\t$0 --acs http://acme.okta.com/auth/saml20/exampleidp --aud https://www.okta.com/saml2/service-provider/spf5aFRRXFGIMAYXQPNV', '')
   .check(function(argv, aliases) {
-    if (!fs.existsSync(argv.cert)) {
+
+    if (fs.existsSync(argv.cert)) {
+      argv.cert = fs.readFileSync(argv.cert);
+    } else if (isCertString(argv.cert)) {
+      argv.cert = bufferFromString(argv.cert);
+    } else if (!fs.existsSync(argv.cert)) {
       return 'IdP Signature PublicKey Certificate "' + argv.cert + '" is not a valid file path.\n' +
         "Please generate a key-pair for the IdP using the following openssl command:\n" +
         "\topenssl req -x509 -new -newkey rsa:2048 -nodes -subj '/C=US/ST=California/L=San Francisco/O=JankyCo/CN=Test Identity Provider' -keyout idp-private-key.pem -out idp-public-cert.pem -days 7300"
     }
 
-    if (!fs.existsSync(argv.key)) {
+    if (fs.existsSync(argv.key)) {
+      argv.key = fs.readFileSync(argv.key);
+    } else if (isPrivateKeyString(argv.key)) {
+      argv.key = bufferFromString(argv.key);
+    } else if (!fs.existsSync(argv.key)) {
       return 'IdP Signature PrivateKey Certificate "' + argv.key + '" is not a valid file path.\n' +
         "Please generate a key-pair for the IdP using the following openssl command:\n" +
         "\topenssl req -x509 -new -newkey rsa:2048 -nodes -subj '/C=US/ST=California/L=San Francisco/O=JankyCo/CN=Test Identity Provider' -keyout idp-private-key.pem -out idp-public-cert.pem -days 7300"
     }
-
-    argv.cert = fs.readFileSync(argv.cert);
-    argv.key = fs.readFileSync(argv.key);
     return true;
   })
   .check(function(argv, aliases) {

--- a/app.js
+++ b/app.js
@@ -216,8 +216,8 @@ SimpleProfileMapper.prototype.metadata = config.metadata;
 
 var idpOptions = {
   issuer:                 argv.issuer,
-  cert:                   fs.readFileSync(path.join(__dirname, 'idp-public-cert.pem')),
-  key:                    fs.readFileSync(path.join(__dirname, 'idp-private-key.pem')),
+  cert:                   argv.cert,
+  key:                    argv.key,
   audience:               argv.audience,
   recipient:              argv.acsUrl,
   destination:            argv.acsUrl,

--- a/app.js
+++ b/app.js
@@ -484,7 +484,7 @@ httpServer.listen(app.get('port'), function() {
   var scheme   = argv.https ? 'https' : 'http',
       address  = httpServer.address(),
       hostname = os.hostname();
-      baseUrl  = address.address === '0.0.0.0' ?
+      baseUrl  = address.address === '0.0.0.0' || address.address === '::' ?
         scheme + '://' + hostname + ':' + address.port :
         scheme + '://localhost:' + address.port;
 


### PR DESCRIPTION
This PR fixes the following:

- key/cert arguments always overridden to the local key/cert path
- server bound to ip6 '::' not properly detected as bound to all hosts

This PR also adds:

- the ability to pass key/cert from environment variables