### PR TITLE
Ensure config option has precedence over loading the configFile option

### DIFF
--- a/app.js
+++ b/app.js
@@ -219,6 +219,9 @@ function processArgs(options) {
       return true;
     })
     .check(function(argv, aliases) {
+      if (argv.config) {
+        return true;
+      }
       const configFilePath = resolveFilePath(argv.configFile);
 
       if (!configFilePath) {


### PR DESCRIPTION
Calling `startServer({config: ...})` was not working because the default `configFile` option was always overriding it. This ensures that the passed config is given precedence.