### PR TITLE
Add a bin entry to package.json

### DIFF
--- a/app.js
+++ b/app.js
@@ -546,11 +546,16 @@ function runServer(options) {
   return _runServer(args.parse([]));
 }
 
+function main () {
+  const args = processArgs();
+  _runServer(args.argv);
+}
+
 module.exports = {
   runServer,
+  main,
 };
 
 if (require.main === module) {
-  const args = processArgs();
-  _runServer(args.argv);
+  main();
 }

--- a/bin/run.js
+++ b/bin/run.js
@@ -1,0 +1,7 @@
+#!/usr/bin/env node
+'use strict';
+
+/*
+ * Run easily as a command
+ */
+require('../app').main();

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   "scripts": {
     "start": "node app.js"
   },
+  "bin": "./bin/run.js",
   "engines": {
     "node": ">=6.0.0"
   },


### PR DESCRIPTION
This will allow users to install with the npm i -g option and get the
command saml-idp installed. Packages could declare saml-idp as a
devDependency and more easily run this package with the command.