### PR TITLE
Before publishing, run bower to compile resources.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,10 +14,7 @@ Simply modify Dockerfile to specify your own parameters.
 ## Manual Installation
 
 1. `npm install`
-2. `bower install`
 3. `openssl req -x509 -new -newkey rsa:2048 -nodes -subj '/C=US/ST=California/L=San Francisco/O=JankyCo/CN=Test Identity Provider' -keyout idp-private-key.pem -out idp-public-cert.pem -days 7300`
-
-> [Bower](http://bower.io/), a front-end package manager, can be installed with `npm install -g bower`
 
 ### Usage
 

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
   },
   "main": "./app.js",
   "scripts": {
-    "start": "node app.js"
+    "start": "node app.js",
+    "prepare": "bower install"
   },
   "engines": {
     "node": ">=6.0.0"
@@ -37,5 +38,8 @@
     "morgan": "~1.8.1",
     "samlp": "2.1.1",
     "yargs": "^7.0.1"
+  },
+  "devDependencies": {
+    "bower": "^1.8.0"
   }
 }


### PR DESCRIPTION
This reduces the number of steps required for users to use this package
correctly.