### PR TITLE
Include SessionIndex

### DIFF
--- a/app.js
+++ b/app.js
@@ -429,6 +429,8 @@ function _runServer(argv) {
       delete authOptions.encryptionPublicKey;
     }
 
+    authOptions.sessionIndex = 1
+
     // Keep calm and Single Sign On
     console.log('Sending Assertion with Options => \n', authOptions);
     samlp.auth(authOptions)(req, res);


### PR DESCRIPTION
Some SAML libraries* expect a `SessionIndex` tag in the authentication response.
This improves this package's breadth of compatibility and shouldn't cause problems with consumers that don't care about `SessionIndex`.

\* Example: https://github.com/Clever/saml2/blob/953cbd63da8d42ab126b63167cccc7f6660f0cf8/lib/saml2.coffee#L336