### PR TITLE
Fix CSS loading

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,6 @@ ADD ./app.js app.js
 ADD ./config.js config.js
 ADD ./idp-public-cert.pem idp-public-cert.pem
 ADD ./idp-private-key.pem idp-private-key.pem
+ADD ./public public
 
 ENTRYPOINT [ "node",  "app.js", "--acs", "https://foo.okta.com/auth/saml20/example", "--aud", "https://www.okta.com/saml2/service-provider/spf5aFRRXFGIMAYXQPNV" ]

--- a/app.js
+++ b/app.js
@@ -324,6 +324,7 @@ function _runServer(argv) {
   app.set('view engine', 'hbs');
   app.set('view options', { layout: 'layout' })
   app.engine('handlebars', hbs.__express);
+  app.use('/bower_components', express.static(__dirname + '/bower_components'))
 
   // Register Helpers
   hbs.registerHelper('extend', function(name, context) {


### PR DESCRIPTION
Without this patch, running the app from Docker results in many 404
responses for the css and bower files once the SP redirects to the IdP
login page. This patch ensures these routes will be accessible so the
login page will load properly.

Closes #16

Credit to @alexkhimich for posting the fix in the bug report.