### PR TITLE
Fix Encryption Key/Cert Handling

### DIFF
--- a/app.js
+++ b/app.js
@@ -296,6 +296,8 @@ function _runServer(argv) {
     signatureAlgorithm:     'rsa-sha256',
     signResponse:           argv.signResponse,
     encryptAssertion:       argv.encryptAssertion,
+    encryptionCert:	    argv.encryptionCert,
+    encryptionPublicKey:    argv.encryptionPublicKey,
     encryptionAlgorithm:    'http://www.w3.org/2001/04/xmlenc#aes256-cbc',
     keyEncryptionAlgorithm: 'http://www.w3.org/2001/04/xmlenc#rsa-oaep-mgf1p',
     lifetimeInSeconds:      3600,


### PR DESCRIPTION
Currently, the encryption key and certificate are never read from the command line parameters, so the token is never encrypted. This PR reads the values from the command line, thereby enabling the ability to encrypt tokens with the SP public certificate and key. 