### PR TITLE
Allow for config that has no user metadata

### DIFF
--- a/lib/simpleProfileMapper.js
+++ b/lib/simpleProfileMapper.js
@@ -15,11 +15,11 @@ SimpleProfileMapper.prototype.getClaims = function() {
       self._pu[entry.id];
   });
 
-  return claims;
+  return Object.keys(claims).length && claims;
 };
 
 SimpleProfileMapper.prototype.getNameIdentifier = function() {
-  return { 
+  return {
     nameIdentifier:                  this._pu.userName,
     nameIdentifierFormat:            this._pu.nameIdFormat,
     nameIdentifierNameQualifier:     this._pu.nameIdNameQualifier,


### PR DESCRIPTION
If an empty claims object is returned to samlp, it will pass that through to saml20.create. This results in an assertion with an empty AttributeStatement block, which will fail SAML validation. This change ensures that an empty object is never returned, and thus no AttributeStatement will be included.