### PR TITLE
Factoring out prototype mutating logic

### DIFF
--- a/app.js
+++ b/app.js
@@ -336,8 +336,6 @@ function _runServer(argv) {
    * IdP Configuration
    */
 
-  SimpleProfileMapper.prototype.metadata = argv.config.metadata;
-
   const idpOptions = {
     issuer:                 argv.issuer,
     serviceProviderId:      argv.serviceProviderId || argv.audience,
@@ -362,7 +360,7 @@ function _runServer(argv) {
     authnContextClassRef:   argv.authnContextClassRef,
     authnContextDecl:       argv.authnContextDecl,
     includeAttributeNameFormat: true,
-    profileMapper:          SimpleProfileMapper,
+    profileMapper:          SimpleProfileMapper.fromMetadata(argv.config.metadata),
     postEndpointPath:       IDP_PATHS.SSO,
     redirectEndpointPath:   IDP_PATHS.SSO,
     logoutEndpointPaths:    argv.sloUrl ?

--- a/lib/simpleProfileMapper.js
+++ b/lib/simpleProfileMapper.js
@@ -5,11 +5,23 @@ function SimpleProfileMapper (pu) {
   this._pu = pu;
 }
 
+SimpleProfileMapper.fromMetadata = function (metadata) {
+  function CustomProfileMapper(user) {
+    if(!(this instanceof CustomProfileMapper)) {
+      return new CustomProfileMapper(user);
+    }
+    SimpleProfileMapper.call(this, user);
+  }
+  CustomProfileMapper.prototype = Object.create(SimpleProfileMapper.prototype);
+  CustomProfileMapper.prototype.metadata = metadata;
+  return CustomProfileMapper;
+}
+
 SimpleProfileMapper.prototype.getClaims = function() {
   var self = this;
   var claims = {};
 
-  SimpleProfileMapper.prototype.metadata.forEach(function(entry) {
+  this.metadata.forEach(function(entry) {
     claims[entry.id] = entry.multiValue ?
       self._pu[entry.id].split(',') :
       self._pu[entry.id];


### PR DESCRIPTION
Because prototypes are shared across instances, they should not be mutated. This change creates a new prototype chain based on SimpleProfileMapper, rather than mutating it's prototype.

This is needed because SimpleProfileMapper's prototype is shared across multiple calls to `runServer`. This supports the use case of calling `runServer` multiple times in the same process.