### PR TITLE
Pass issuer id on logout request

### DIFF
--- a/app.js
+++ b/app.js
@@ -538,6 +538,7 @@ function _runServer(argv) {
     console.log('Processing SAML SLO request for participant => \n', req.participant);
 
     return samlp.logout({
+      issuer:                 req.idp.options.issuer,
       cert:                   req.idp.options.cert,
       key:                    req.idp.options.key,
       digestAlgorithm:        req.idp.options.digestAlgorithm,


### PR DESCRIPTION
According to the samlp documentation, the issuer is required on logout:
https://github.com/auth0/node-samlp#logout---slo-single-logout

This PR just passes that adds that parameter to the logout request.

Great test idp by the way!