### PR TITLE
Add a --host option.

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,6 +121,7 @@ The following options can either be passed as `--<option>` or to `runServer` in 
 
 Option (* required)      | Description                                                                                         | Default
 -----------------------: | --------------------------------------------------------------------------------------------------- | ----------
+**host**                 | IdP Web Server Listender Host                                                                       | localhost
 **port**                 | IdP Web Server Listener Port                                                                        | 7000
 **cert** _*_             | IdP Signature PublicKey Certificate                                                                 | ./idp-public-cert.pem
 **key** _*_              | IdP Signature PrivateKey Certificate                                                                | ./idp-private-key.pem

--- a/app.js
+++ b/app.js
@@ -176,6 +176,11 @@ function processArgs(args, options) {
         'Usage:\n\t$0 --acsUrl {url} --audience {uri}')
     .alias({h: 'help'})
     .options({
+      host: {
+        description: 'IdP Web Server Listener Host',
+        required: false,
+        default: 'localhost'
+      },
       port: {
         description: 'IdP Web Server Listener Port',
         required: true,
@@ -352,7 +357,7 @@ function _runServer(argv) {
 
   console.log(dedent(chalk`
     Listener Port:
-      {cyan ${argv.port}}
+      {cyan ${argv.host}:${argv.port}}
     HTTPS Enabled:
       {cyan ${argv.https}}
 
@@ -466,6 +471,7 @@ function _runServer(argv) {
    * App Environment
    */
 
+  app.set('host', process.env.HOST || argv.host);
   app.set('port', process.env.PORT || argv.port);
   app.set('views', path.join(__dirname, 'views'));
 
@@ -783,9 +789,9 @@ function _runServer(argv) {
    * Start IdP Web Server
    */
 
-  console.log(chalk`Starting IdP server on port {cyan ${app.get('port')}}...\n`);
+  console.log(chalk`Starting IdP server on port {cyan ${app.get('host')}:${app.get('port')}}...\n`);
 
-  httpServer.listen(app.get('port'), function() {
+  httpServer.listen(app.get('port'), app.get('host'), function() {
     const scheme          = argv.https ? 'https' : 'http',
           {address, port} = httpServer.address(),
           hostname        = WILDCARD_ADDRESSES.includes(address) ? os.hostname() : 'localhost',


### PR DESCRIPTION
On my Mac the `saml-idp` command was not loading on localhost
port 7000 but was telling me it was on "SeanPerryMacBook.local".
It was a lie. Turns out I had 7000 in use from a Docker instance
I forgot about.

This PR provides people the ability to choose which hostname to listen on.
For me, being able to set the host as 0.0.0.0 causes an error to
occur if the port is in use while localhost lies and claims to work but does not.