### PR TITLE
feat: provide docker image hosted on ghcr.io

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,38 @@
+name: Build and Push Docker Image
+
+on:
+  workflow_dispatch:
+  workflow_call:
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - uses: actions/checkout@v4
+
+      - run: echo "version=$(jq -r .version package.json)" >> $GITHUB_OUTPUT
+        id: version
+
+      - uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - uses: docker/metadata-action@v5
+        id: meta
+        with:
+          images: ghcr.io/${{ github.repository }}
+          tags: |
+            type=raw,value=${{ steps.version.outputs.version }}
+            type=raw,value=latest
+
+      - uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/.github/workflows/pr-merge.yml
+++ b/.github/workflows/pr-merge.yml
@@ -1,0 +1,29 @@
+name: PR Merge Pipeline
+
+on:
+  pull_request:
+    branches:
+      - master
+    types:
+      - closed
+
+jobs:
+  version-bumped:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+
+    outputs:
+      result: ${{ steps.check.outputs.has-updated }}
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: MontyD/package-json-updated-action@1.0.1
+        id: check
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  docker-build:
+    if: needs.version-bumped.outputs.result == 'true'
+    needs: version-bumped
+
+    uses: ./.github/workflows/docker.yml

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "saml-idp",
   "description": "Test Identity Provider (IdP) for SAML 2.0 Web Browser SSO Profile",
   "type": "commonjs",
-  "version": "1.3",
+  "version": "1.3.1",
   "private": false,
   "author": "Karl McGuinness",
   "keywords": [


### PR DESCRIPTION
This would close #94 🙏

The CI is built around 2 actions, one triggering at merge and only publishing new version when you bump the package.json version, and it would call a 2nd one. I find this pattern most useful when need to re-trigger a broken docker build without having to bump the version again.

This is manual, as in, you need to bump the version by yourself, but it's also the less opinionated. You could want to implement semantic releases or any other automated release system too.

PS: sorry for the closed PRs, github ui has this need to select upstream rather than origin by default and i was too fast in opening my PRs 🙏