### PR TITLE
Pin to node:18-alpine — node:latest is Node 26 and breaks yargs ESM

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:latest
+FROM node:18-alpine
 
 ADD ./package.json package.json
 RUN npm install

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,8 @@
 FROM node:18-alpine
 
+# samlp dependency is github:mcguinness/node-samlp - npm needs git to clone it.
+RUN apk add --no-cache git
+
 ADD ./package.json package.json
 RUN npm install
 

--- a/Dockerfile
+++ b/Dockerfile
@@ -17,4 +17,7 @@ ADD ./idp-public-cert.pem idp-public-cert.pem
 ADD ./idp-private-key.pem idp-private-key.pem
 ADD ./public public
 
-ENTRYPOINT [ "node",  "app.js", "--acs", "https://foo.okta.com/auth/saml20/example", "--aud", "https://www.okta.com/saml2/service-provider/spf5aFRRXFGIMAYXQPNV" ]
+COPY entrypoint.sh /app/entrypoint.sh
+RUN chmod +x /app/entrypoint.sh
+
+ENTRYPOINT [ "/app/entrypoint.sh" ]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,5 +1,12 @@
-saml-idp:
-   build: .
-   ports:
-    - "7000:7000"
-   net: "host"
+services:
+  saml-idp:
+    build:
+      context: .
+      dockerfile: Dockerfile
+    expose:
+      - "7000"
+    environment:
+      - SAML_ACS_URL=${SAML_ACS_URL}
+      - SAML_AUDIENCE=${SAML_AUDIENCE}
+      - SAML_SLO_URL=${SAML_SLO_URL}
+      - SAML_ISSUER=${SAML_ISSUER:-urn:example:idp}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,31 @@
+#!/bin/sh
+# Translate SAML_* env vars into mcguinness/saml-idp CLI flags. Also
+# binds 0.0.0.0 so Dokploy/Traefik (in a different container) can
+# actually reach the IdP — the upstream default is localhost which
+# is the in-container loopback only.
+
+set -e
+
+CMD="node app.js --host 0.0.0.0 --port ${SAML_PORT:-7000}"
+
+if [ -n "$SAML_ACS_URL" ]; then
+  CMD="$CMD --acsUrl \"$SAML_ACS_URL\""
+fi
+if [ -n "$SAML_AUDIENCE" ]; then
+  CMD="$CMD --audience \"$SAML_AUDIENCE\""
+fi
+if [ -n "$SAML_SLO_URL" ]; then
+  CMD="$CMD --sloUrl \"$SAML_SLO_URL\""
+fi
+if [ -n "$SAML_ISSUER" ]; then
+  CMD="$CMD --iss \"$SAML_ISSUER\""
+fi
+
+echo "Starting SAML IdP"
+echo "  Host:     0.0.0.0:${SAML_PORT:-7000}"
+echo "  ACS:      ${SAML_ACS_URL:-<not set>}"
+echo "  Audience: ${SAML_AUDIENCE:-<not set>}"
+echo "  SLO:      ${SAML_SLO_URL:-<not set>}"
+echo "  Issuer:   ${SAML_ISSUER:-urn:example:idp}"
+
+eval $CMD


### PR DESCRIPTION
Latest Node tag is currently Node 26.x. yargs (a dependency in this tree) loads its CJS entrypoint via require() from a file Node 26 treats as an ES module:

  ReferenceError: require is not defined in ES module scope, you can
  use import instead
    at file:///node_modules/yargs/yargs:3:69

Node 18 LTS doesn't reproduce. Pinning to the version range mcguinness upstream actually tests against.